### PR TITLE
feat: add hobby CRUD APIs

### DIFF
--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/HobbyController.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/HobbyController.kt
@@ -1,19 +1,29 @@
 package com.onuldo.adapter.inbound.web
 
+import com.onuldo.adapter.inbound.web.dto.CreateHobbyRequest
+import com.onuldo.adapter.inbound.web.dto.UpdateHobbyRequest
 import com.onuldo.common.dto.ApiResponse
+import com.onuldo.port.inbound.hobby.model.CreateHobbyCommand
 import com.onuldo.port.inbound.hobby.model.HobbyResponse
+import com.onuldo.port.inbound.hobby.model.UpdateHobbyCommand
+import com.onuldo.port.inbound.hobby.usecase.CreateHobbyUseCase
+import com.onuldo.port.inbound.hobby.usecase.DeleteHobbyUseCase
 import com.onuldo.port.inbound.hobby.usecase.GetHobbyListUseCase
+import com.onuldo.port.inbound.hobby.usecase.UpdateHobbyUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "Hobby", description = "취미 API")
 @RestController
 @RequestMapping("/api/hobbies")
 class HobbyController(
-    private val getHobbyListUseCase: GetHobbyListUseCase
+    private val getHobbyListUseCase: GetHobbyListUseCase,
+    private val createHobbyUseCase: CreateHobbyUseCase,
+    private val updateHobbyUseCase: UpdateHobbyUseCase,
+    private val deleteHobbyUseCase: DeleteHobbyUseCase
 ) {
 
     @Operation(summary = "취미 목록 조회", description = "활성화된 모든 취미 목록을 조회합니다.")
@@ -22,5 +32,43 @@ class HobbyController(
         val hobbies = getHobbyListUseCase.execute()
         return ApiResponse.success(hobbies, message = "취미 목록을 조회했습니다.")
     }
-}
 
+    @Operation(summary = "취미 생성", description = "새로운 취미를 생성합니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createHobby(@Valid @RequestBody request: CreateHobbyRequest): ApiResponse<HobbyResponse> {
+        val command = CreateHobbyCommand(
+            name = request.name,
+            description = request.description,
+            iconUrl = request.iconUrl,
+            colorCode = request.colorCode
+        )
+        val hobby = createHobbyUseCase.execute(command)
+        return ApiResponse.success(hobby, message = "취미를 생성했습니다.")
+    }
+
+    @Operation(summary = "취미 수정", description = "기존 취미 정보를 수정합니다.")
+    @PutMapping("/{id}")
+    fun updateHobby(
+        @PathVariable id: Long,
+        @Valid @RequestBody request: UpdateHobbyRequest
+    ): ApiResponse<HobbyResponse> {
+        val command = UpdateHobbyCommand(
+            id = id,
+            name = request.name,
+            description = request.description,
+            iconUrl = request.iconUrl,
+            colorCode = request.colorCode
+        )
+        val hobby = updateHobbyUseCase.execute(command)
+        return ApiResponse.success(hobby, message = "취미를 수정했습니다.")
+    }
+
+    @Operation(summary = "취미 삭제", description = "취미를 비활성화합니다.")
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteHobby(@PathVariable id: Long): ApiResponse<Unit> {
+        deleteHobbyUseCase.execute(id)
+        return ApiResponse.success(message = "취미를 삭제했습니다.")
+    }
+}

--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/CreateHobbyRequest.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/CreateHobbyRequest.kt
@@ -1,0 +1,18 @@
+package com.onuldo.adapter.inbound.web.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateHobbyRequest(
+    @field:NotBlank(message = "취미 이름은 필수입니다.")
+    @field:Size(max = 50, message = "취미 이름은 50자 이하여야 합니다.")
+    val name: String,
+
+    val description: String? = null,
+
+    @field:Size(max = 255, message = "아이콘 URL은 255자 이하여야 합니다.")
+    val iconUrl: String? = null,
+
+    @field:Size(max = 7, message = "색상 코드는 7자 이하여야 합니다.")
+    val colorCode: String? = null
+)

--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/UpdateHobbyRequest.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/UpdateHobbyRequest.kt
@@ -1,0 +1,16 @@
+package com.onuldo.adapter.inbound.web.dto
+
+import jakarta.validation.constraints.Size
+
+data class UpdateHobbyRequest(
+    @field:Size(max = 50, message = "취미 이름은 50자 이하여야 합니다.")
+    val name: String? = null,
+
+    val description: String? = null,
+
+    @field:Size(max = 255, message = "아이콘 URL은 255자 이하여야 합니다.")
+    val iconUrl: String? = null,
+
+    @field:Size(max = 7, message = "색상 코드는 7자 이하여야 합니다.")
+    val colorCode: String? = null
+)

--- a/src/main/kotlin/com/onuldo/application/hobby/CreateHobbyService.kt
+++ b/src/main/kotlin/com/onuldo/application/hobby/CreateHobbyService.kt
@@ -1,0 +1,40 @@
+package com.onuldo.application.hobby
+
+import com.onuldo.common.exception.DuplicateResourceException
+import com.onuldo.domain.hobby.Hobby
+import com.onuldo.port.inbound.hobby.model.CreateHobbyCommand
+import com.onuldo.port.inbound.hobby.model.HobbyResponse
+import com.onuldo.port.inbound.hobby.usecase.CreateHobbyUseCase
+import com.onuldo.port.outbound.hobby.HobbyRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CreateHobbyService(
+    private val hobbyRepository: HobbyRepository
+) : CreateHobbyUseCase {
+
+    @Transactional
+    override fun execute(command: CreateHobbyCommand): HobbyResponse {
+        if (hobbyRepository.existsByName(command.name)) {
+            throw DuplicateResourceException("취미", "이미 존재하는 취미입니다: ${command.name}")
+        }
+
+        val hobby = Hobby(
+            name = command.name,
+            description = command.description,
+            iconUrl = command.iconUrl,
+            colorCode = command.colorCode
+        )
+
+        val savedHobby = hobbyRepository.save(hobby)
+
+        return HobbyResponse(
+            id = savedHobby.id ?: throw IllegalStateException("취미 ID가 없습니다."),
+            name = savedHobby.name,
+            description = savedHobby.description,
+            iconUrl = savedHobby.iconUrl,
+            colorCode = savedHobby.colorCode
+        )
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/hobby/DeleteHobbyService.kt
+++ b/src/main/kotlin/com/onuldo/application/hobby/DeleteHobbyService.kt
@@ -1,0 +1,22 @@
+package com.onuldo.application.hobby
+
+import com.onuldo.common.exception.ResourceNotFoundException
+import com.onuldo.port.inbound.hobby.usecase.DeleteHobbyUseCase
+import com.onuldo.port.outbound.hobby.HobbyRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class DeleteHobbyService(
+    private val hobbyRepository: HobbyRepository
+) : DeleteHobbyUseCase {
+
+    @Transactional
+    override fun execute(id: Long) {
+        val hobby = hobbyRepository.findById(id)
+            ?: throw ResourceNotFoundException("취미", id)
+
+        hobby.deactivate()
+        hobbyRepository.save(hobby)
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/hobby/UpdateHobbyService.kt
+++ b/src/main/kotlin/com/onuldo/application/hobby/UpdateHobbyService.kt
@@ -1,0 +1,49 @@
+package com.onuldo.application.hobby
+
+import com.onuldo.common.exception.DuplicateResourceException
+import com.onuldo.common.exception.ResourceNotFoundException
+import com.onuldo.domain.hobby.Hobby
+import com.onuldo.port.inbound.hobby.model.HobbyResponse
+import com.onuldo.port.inbound.hobby.model.UpdateHobbyCommand
+import com.onuldo.port.inbound.hobby.usecase.UpdateHobbyUseCase
+import com.onuldo.port.outbound.hobby.HobbyRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UpdateHobbyService(
+    private val hobbyRepository: HobbyRepository
+) : UpdateHobbyUseCase {
+
+    @Transactional
+    override fun execute(command: UpdateHobbyCommand): HobbyResponse {
+        val hobby = hobbyRepository.findById(command.id)
+            ?: throw ResourceNotFoundException("취미", command.id)
+
+        command.name?.let { newName ->
+            if (newName != hobby.name && hobbyRepository.existsByName(newName)) {
+                throw DuplicateResourceException("취미", "이미 존재하는 취미입니다: $newName")
+            }
+        }
+
+        val updatedHobby = Hobby(
+            name = command.name ?: hobby.name,
+            description = command.description ?: hobby.description,
+            iconUrl = command.iconUrl ?: hobby.iconUrl,
+            colorCode = command.colorCode ?: hobby.colorCode,
+            isActive = hobby.isActive
+        ).apply {
+            this.id = hobby.id
+        }
+
+        val savedHobby = hobbyRepository.save(updatedHobby)
+
+        return HobbyResponse(
+            id = savedHobby.id ?: throw IllegalStateException("취미 ID가 없습니다."),
+            name = savedHobby.name,
+            description = savedHobby.description,
+            iconUrl = savedHobby.iconUrl,
+            colorCode = savedHobby.colorCode
+        )
+    }
+}

--- a/src/main/kotlin/com/onuldo/domain/comment/Comment.kt
+++ b/src/main/kotlin/com/onuldo/domain/comment/Comment.kt
@@ -7,8 +7,6 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 
 /**
  * 댓글 엔티티

--- a/src/main/kotlin/com/onuldo/port/inbound/hobby/model/CreateHobbyCommand.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/hobby/model/CreateHobbyCommand.kt
@@ -1,0 +1,8 @@
+package com.onuldo.port.inbound.hobby.model
+
+data class CreateHobbyCommand(
+    val name: String,
+    val description: String? = null,
+    val iconUrl: String? = null,
+    val colorCode: String? = null
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/hobby/model/UpdateHobbyCommand.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/hobby/model/UpdateHobbyCommand.kt
@@ -1,0 +1,9 @@
+package com.onuldo.port.inbound.hobby.model
+
+data class UpdateHobbyCommand(
+    val id: Long,
+    val name: String? = null,
+    val description: String? = null,
+    val iconUrl: String? = null,
+    val colorCode: String? = null
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/hobby/usecase/CreateHobbyUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/hobby/usecase/CreateHobbyUseCase.kt
@@ -1,0 +1,8 @@
+package com.onuldo.port.inbound.hobby.usecase
+
+import com.onuldo.port.inbound.hobby.model.CreateHobbyCommand
+import com.onuldo.port.inbound.hobby.model.HobbyResponse
+
+interface CreateHobbyUseCase {
+    fun execute(command: CreateHobbyCommand): HobbyResponse
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/hobby/usecase/DeleteHobbyUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/hobby/usecase/DeleteHobbyUseCase.kt
@@ -1,0 +1,5 @@
+package com.onuldo.port.inbound.hobby.usecase
+
+interface DeleteHobbyUseCase {
+    fun execute(id: Long)
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/hobby/usecase/UpdateHobbyUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/hobby/usecase/UpdateHobbyUseCase.kt
@@ -1,0 +1,8 @@
+package com.onuldo.port.inbound.hobby.usecase
+
+import com.onuldo.port.inbound.hobby.model.HobbyResponse
+import com.onuldo.port.inbound.hobby.model.UpdateHobbyCommand
+
+interface UpdateHobbyUseCase {
+    fun execute(command: UpdateHobbyCommand): HobbyResponse
+}


### PR DESCRIPTION
## Summary
- Add hobby create, update, delete APIs
- Add UseCase, Service, DTO for hobby management
- Fix duplicate imports in Comment.kt

## API Endpoints
- `POST /api/hobbies` - Create hobby
- `PUT /api/hobbies/{id}` - Update hobby
- `DELETE /api/hobbies/{id}` - Delete hobby (soft delete)

Closes #4