### PR TITLE
feat: add timer start/pause/resume/stop APIs

### DIFF
--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/TimerController.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/TimerController.kt
@@ -1,0 +1,83 @@
+package com.onuldo.adapter.inbound.web
+
+import com.onuldo.adapter.inbound.web.dto.StartTimerRequest
+import com.onuldo.common.dto.ApiResponse
+import com.onuldo.common.security.SecurityUtils
+import com.onuldo.port.inbound.timer.model.StartTimerCommand
+import com.onuldo.port.inbound.timer.model.TimerResponse
+import com.onuldo.port.inbound.timer.usecase.GetCurrentTimerUseCase
+import com.onuldo.port.inbound.timer.usecase.PauseTimerUseCase
+import com.onuldo.port.inbound.timer.usecase.ResumeTimerUseCase
+import com.onuldo.port.inbound.timer.usecase.StartTimerUseCase
+import com.onuldo.port.inbound.timer.usecase.StopTimerUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Timer", description = "타이머 API")
+@RestController
+@RequestMapping("/api/timers")
+class TimerController(
+    private val securityUtils: SecurityUtils,
+    private val startTimerUseCase: StartTimerUseCase,
+    private val pauseTimerUseCase: PauseTimerUseCase,
+    private val resumeTimerUseCase: ResumeTimerUseCase,
+    private val stopTimerUseCase: StopTimerUseCase,
+    private val getCurrentTimerUseCase: GetCurrentTimerUseCase
+) {
+
+    @Operation(summary = "타이머 시작", description = "새로운 타이머를 시작합니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun startTimer(
+        request: HttpServletRequest,
+        @Valid @RequestBody body: StartTimerRequest
+    ): ApiResponse<TimerResponse> {
+        val userId = securityUtils.getCurrentUserId(request)
+        val command = StartTimerCommand(
+            userId = userId,
+            hobbyId = body.hobbyId
+        )
+        val timer = startTimerUseCase.execute(command)
+        return ApiResponse.success(timer, message = "타이머를 시작했습니다.")
+    }
+
+    @Operation(summary = "타이머 일시정지", description = "실행 중인 타이머를 일시정지합니다.")
+    @PostMapping("/pause")
+    fun pauseTimer(request: HttpServletRequest): ApiResponse<TimerResponse> {
+        val userId = securityUtils.getCurrentUserId(request)
+        val timer = pauseTimerUseCase.execute(userId)
+        return ApiResponse.success(timer, message = "타이머를 일시정지했습니다.")
+    }
+
+    @Operation(summary = "타이머 재개", description = "일시정지된 타이머를 재개합니다.")
+    @PostMapping("/resume")
+    fun resumeTimer(request: HttpServletRequest): ApiResponse<TimerResponse> {
+        val userId = securityUtils.getCurrentUserId(request)
+        val timer = resumeTimerUseCase.execute(userId)
+        return ApiResponse.success(timer, message = "타이머를 재개했습니다.")
+    }
+
+    @Operation(summary = "타이머 종료", description = "실행 중인 타이머를 종료합니다.")
+    @PostMapping("/stop")
+    fun stopTimer(request: HttpServletRequest): ApiResponse<TimerResponse> {
+        val userId = securityUtils.getCurrentUserId(request)
+        val timer = stopTimerUseCase.execute(userId)
+        return ApiResponse.success(timer, message = "타이머를 종료했습니다.")
+    }
+
+    @Operation(summary = "현재 타이머 조회", description = "현재 실행 중인 타이머를 조회합니다.")
+    @GetMapping("/current")
+    fun getCurrentTimer(request: HttpServletRequest): ApiResponse<TimerResponse?> {
+        val userId = securityUtils.getCurrentUserId(request)
+        val timer = getCurrentTimerUseCase.execute(userId)
+        return if (timer != null) {
+            ApiResponse.success(timer, message = "현재 타이머를 조회했습니다.")
+        } else {
+            ApiResponse.success(null, message = "실행 중인 타이머가 없습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/StartTimerRequest.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/StartTimerRequest.kt
@@ -1,0 +1,8 @@
+package com.onuldo.adapter.inbound.web.dto
+
+import jakarta.validation.constraints.NotNull
+
+data class StartTimerRequest(
+    @field:NotNull(message = "취미 ID는 필수입니다.")
+    val hobbyId: Long
+)

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/timer/TimerJpaRepository.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/timer/TimerJpaRepository.kt
@@ -1,0 +1,14 @@
+package com.onuldo.adapter.outbound.persistence.timer
+
+import com.onuldo.domain.timer.Timer
+import com.onuldo.domain.timer.TimerStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface TimerJpaRepository : JpaRepository<Timer, Long> {
+    fun findByUserId(userId: Long): List<Timer>
+    fun findByUserIdAndStatus(userId: Long, status: TimerStatus): Timer?
+
+    @Query("SELECT t FROM Timer t WHERE t.userId = :userId AND t.status IN ('RUNNING', 'PAUSED')")
+    fun findActiveTimerByUserId(userId: Long): Timer?
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/timer/TimerRepositoryImpl.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/timer/TimerRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.onuldo.adapter.outbound.persistence.timer
+
+import com.onuldo.domain.timer.Timer
+import com.onuldo.domain.timer.TimerStatus
+import com.onuldo.port.outbound.timer.TimerRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class TimerRepositoryImpl(
+    private val timerJpaRepository: TimerJpaRepository
+) : TimerRepository {
+
+    override fun save(timer: Timer): Timer {
+        return timerJpaRepository.save(timer)
+    }
+
+    override fun findById(id: Long): Timer? {
+        return timerJpaRepository.findByIdOrNull(id)
+    }
+
+    override fun findByUserId(userId: Long): List<Timer> {
+        return timerJpaRepository.findByUserId(userId)
+    }
+
+    override fun findByUserIdAndStatus(userId: Long, status: TimerStatus): Timer? {
+        return timerJpaRepository.findByUserIdAndStatus(userId, status)
+    }
+
+    override fun findActiveTimerByUserId(userId: Long): Timer? {
+        return timerJpaRepository.findActiveTimerByUserId(userId)
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/timer/GetCurrentTimerService.kt
+++ b/src/main/kotlin/com/onuldo/application/timer/GetCurrentTimerService.kt
@@ -1,0 +1,31 @@
+package com.onuldo.application.timer
+
+import com.onuldo.domain.timer.Timer
+import com.onuldo.port.inbound.timer.model.TimerResponse
+import com.onuldo.port.inbound.timer.usecase.GetCurrentTimerUseCase
+import com.onuldo.port.outbound.timer.TimerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetCurrentTimerService(
+    private val timerRepository: TimerRepository
+) : GetCurrentTimerUseCase {
+
+    @Transactional(readOnly = true)
+    override fun execute(userId: Long): TimerResponse? {
+        val timer = timerRepository.findActiveTimerByUserId(userId)
+        return timer?.let { toResponse(it) }
+    }
+
+    private fun toResponse(timer: Timer): TimerResponse {
+        return TimerResponse(
+            id = timer.id ?: throw IllegalStateException("타이머 ID가 없습니다."),
+            hobbyId = timer.hobbyId,
+            startTime = timer.startTime,
+            endTime = timer.endTime,
+            durationSeconds = timer.getCurrentDuration(),
+            status = timer.status
+        )
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/timer/PauseTimerService.kt
+++ b/src/main/kotlin/com/onuldo/application/timer/PauseTimerService.kt
@@ -1,0 +1,37 @@
+package com.onuldo.application.timer
+
+import com.onuldo.common.exception.ResourceNotFoundException
+import com.onuldo.domain.timer.Timer
+import com.onuldo.port.inbound.timer.model.TimerResponse
+import com.onuldo.port.inbound.timer.usecase.PauseTimerUseCase
+import com.onuldo.port.outbound.timer.TimerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PauseTimerService(
+    private val timerRepository: TimerRepository
+) : PauseTimerUseCase {
+
+    @Transactional
+    override fun execute(userId: Long): TimerResponse {
+        val timer = timerRepository.findActiveTimerByUserId(userId)
+            ?: throw ResourceNotFoundException("활성 타이머")
+
+        timer.pause()
+        val savedTimer = timerRepository.save(timer)
+
+        return toResponse(savedTimer)
+    }
+
+    private fun toResponse(timer: Timer): TimerResponse {
+        return TimerResponse(
+            id = timer.id ?: throw IllegalStateException("타이머 ID가 없습니다."),
+            hobbyId = timer.hobbyId,
+            startTime = timer.startTime,
+            endTime = timer.endTime,
+            durationSeconds = timer.getCurrentDuration(),
+            status = timer.status
+        )
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/timer/ResumeTimerService.kt
+++ b/src/main/kotlin/com/onuldo/application/timer/ResumeTimerService.kt
@@ -1,0 +1,38 @@
+package com.onuldo.application.timer
+
+import com.onuldo.common.exception.ResourceNotFoundException
+import com.onuldo.domain.timer.Timer
+import com.onuldo.domain.timer.TimerStatus
+import com.onuldo.port.inbound.timer.model.TimerResponse
+import com.onuldo.port.inbound.timer.usecase.ResumeTimerUseCase
+import com.onuldo.port.outbound.timer.TimerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ResumeTimerService(
+    private val timerRepository: TimerRepository
+) : ResumeTimerUseCase {
+
+    @Transactional
+    override fun execute(userId: Long): TimerResponse {
+        val timer = timerRepository.findByUserIdAndStatus(userId, TimerStatus.PAUSED)
+            ?: throw ResourceNotFoundException("일시정지된 타이머")
+
+        timer.resume()
+        val savedTimer = timerRepository.save(timer)
+
+        return toResponse(savedTimer)
+    }
+
+    private fun toResponse(timer: Timer): TimerResponse {
+        return TimerResponse(
+            id = timer.id ?: throw IllegalStateException("타이머 ID가 없습니다."),
+            hobbyId = timer.hobbyId,
+            startTime = timer.startTime,
+            endTime = timer.endTime,
+            durationSeconds = timer.getCurrentDuration(),
+            status = timer.status
+        )
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/timer/StartTimerService.kt
+++ b/src/main/kotlin/com/onuldo/application/timer/StartTimerService.kt
@@ -1,0 +1,55 @@
+package com.onuldo.application.timer
+
+import com.onuldo.common.exception.CustomException
+import com.onuldo.common.exception.ErrorCode
+import com.onuldo.common.exception.ResourceNotFoundException
+import com.onuldo.domain.timer.Timer
+import com.onuldo.port.inbound.timer.model.StartTimerCommand
+import com.onuldo.port.inbound.timer.model.TimerResponse
+import com.onuldo.port.inbound.timer.usecase.StartTimerUseCase
+import com.onuldo.port.outbound.hobby.HobbyRepository
+import com.onuldo.port.outbound.timer.TimerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class StartTimerService(
+    private val timerRepository: TimerRepository,
+    private val hobbyRepository: HobbyRepository
+) : StartTimerUseCase {
+
+    @Transactional
+    override fun execute(command: StartTimerCommand): TimerResponse {
+        // Check if hobby exists
+        hobbyRepository.findById(command.hobbyId)
+            ?: throw ResourceNotFoundException("취미", command.hobbyId)
+
+        // Check if user already has an active timer
+        val activeTimer = timerRepository.findActiveTimerByUserId(command.userId)
+        if (activeTimer != null) {
+            throw CustomException(ErrorCode.TIMER_ALREADY_STARTED)
+        }
+
+        val timer = Timer(
+            userId = command.userId,
+            hobbyId = command.hobbyId,
+            startTime = LocalDateTime.now()
+        )
+
+        val savedTimer = timerRepository.save(timer)
+
+        return toResponse(savedTimer)
+    }
+
+    private fun toResponse(timer: Timer): TimerResponse {
+        return TimerResponse(
+            id = timer.id ?: throw IllegalStateException("타이머 ID가 없습니다."),
+            hobbyId = timer.hobbyId,
+            startTime = timer.startTime,
+            endTime = timer.endTime,
+            durationSeconds = timer.getCurrentDuration(),
+            status = timer.status
+        )
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/timer/StopTimerService.kt
+++ b/src/main/kotlin/com/onuldo/application/timer/StopTimerService.kt
@@ -1,0 +1,37 @@
+package com.onuldo.application.timer
+
+import com.onuldo.common.exception.ResourceNotFoundException
+import com.onuldo.domain.timer.Timer
+import com.onuldo.port.inbound.timer.model.TimerResponse
+import com.onuldo.port.inbound.timer.usecase.StopTimerUseCase
+import com.onuldo.port.outbound.timer.TimerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class StopTimerService(
+    private val timerRepository: TimerRepository
+) : StopTimerUseCase {
+
+    @Transactional
+    override fun execute(userId: Long): TimerResponse {
+        val timer = timerRepository.findActiveTimerByUserId(userId)
+            ?: throw ResourceNotFoundException("활성 타이머")
+
+        timer.stop()
+        val savedTimer = timerRepository.save(timer)
+
+        return toResponse(savedTimer)
+    }
+
+    private fun toResponse(timer: Timer): TimerResponse {
+        return TimerResponse(
+            id = timer.id ?: throw IllegalStateException("타이머 ID가 없습니다."),
+            hobbyId = timer.hobbyId,
+            startTime = timer.startTime,
+            endTime = timer.endTime,
+            durationSeconds = timer.getCurrentDuration(),
+            status = timer.status
+        )
+    }
+}

--- a/src/main/kotlin/com/onuldo/common/security/SecurityUtils.kt
+++ b/src/main/kotlin/com/onuldo/common/security/SecurityUtils.kt
@@ -1,0 +1,31 @@
+package com.onuldo.common.security
+
+import com.onuldo.common.exception.UnauthorizedException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+
+@Component
+class SecurityUtils(
+    private val jwtTokenProvider: JwtTokenProvider
+) {
+
+    fun getCurrentUserId(request: HttpServletRequest): Long {
+        val token = resolveToken(request)
+            ?: throw UnauthorizedException("인증 토큰이 필요합니다.")
+
+        if (!jwtTokenProvider.validateToken(token) || !jwtTokenProvider.isAccessToken(token)) {
+            throw UnauthorizedException("유효하지 않은 토큰입니다.")
+        }
+
+        return jwtTokenProvider.getUserId(token)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearer = request.getHeader("Authorization") ?: return null
+        return if (bearer.startsWith("Bearer ", ignoreCase = true)) {
+            bearer.substring(7)
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/domain/comment/Comment.kt
+++ b/src/main/kotlin/com/onuldo/domain/comment/Comment.kt
@@ -7,8 +7,6 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 
 /**
  * 댓글 엔티티

--- a/src/main/kotlin/com/onuldo/port/inbound/timer/model/StartTimerCommand.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/timer/model/StartTimerCommand.kt
@@ -1,0 +1,6 @@
+package com.onuldo.port.inbound.timer.model
+
+data class StartTimerCommand(
+    val userId: Long,
+    val hobbyId: Long
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/timer/model/TimerResponse.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/timer/model/TimerResponse.kt
@@ -1,0 +1,13 @@
+package com.onuldo.port.inbound.timer.model
+
+import com.onuldo.domain.timer.TimerStatus
+import java.time.LocalDateTime
+
+data class TimerResponse(
+    val id: Long,
+    val hobbyId: Long,
+    val startTime: LocalDateTime,
+    val endTime: LocalDateTime?,
+    val durationSeconds: Int,
+    val status: TimerStatus
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/GetCurrentTimerUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/GetCurrentTimerUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.timer.usecase
+
+import com.onuldo.port.inbound.timer.model.TimerResponse
+
+interface GetCurrentTimerUseCase {
+    fun execute(userId: Long): TimerResponse?
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/PauseTimerUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/PauseTimerUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.timer.usecase
+
+import com.onuldo.port.inbound.timer.model.TimerResponse
+
+interface PauseTimerUseCase {
+    fun execute(userId: Long): TimerResponse
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/ResumeTimerUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/ResumeTimerUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.timer.usecase
+
+import com.onuldo.port.inbound.timer.model.TimerResponse
+
+interface ResumeTimerUseCase {
+    fun execute(userId: Long): TimerResponse
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/StartTimerUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/StartTimerUseCase.kt
@@ -1,0 +1,8 @@
+package com.onuldo.port.inbound.timer.usecase
+
+import com.onuldo.port.inbound.timer.model.StartTimerCommand
+import com.onuldo.port.inbound.timer.model.TimerResponse
+
+interface StartTimerUseCase {
+    fun execute(command: StartTimerCommand): TimerResponse
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/StopTimerUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/timer/usecase/StopTimerUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.timer.usecase
+
+import com.onuldo.port.inbound.timer.model.TimerResponse
+
+interface StopTimerUseCase {
+    fun execute(userId: Long): TimerResponse
+}

--- a/src/main/kotlin/com/onuldo/port/outbound/timer/TimerRepository.kt
+++ b/src/main/kotlin/com/onuldo/port/outbound/timer/TimerRepository.kt
@@ -1,0 +1,12 @@
+package com.onuldo.port.outbound.timer
+
+import com.onuldo.domain.timer.Timer
+import com.onuldo.domain.timer.TimerStatus
+
+interface TimerRepository {
+    fun save(timer: Timer): Timer
+    fun findById(id: Long): Timer?
+    fun findByUserId(userId: Long): List<Timer>
+    fun findByUserIdAndStatus(userId: Long, status: TimerStatus): Timer?
+    fun findActiveTimerByUserId(userId: Long): Timer?
+}


### PR DESCRIPTION
## Summary
- Add timer API endpoints for start, pause, resume, stop
- Add SecurityUtils for JWT user extraction
- Fix duplicate imports in Comment.kt

## API Endpoints
- `POST /api/timers` - Start timer
- `POST /api/timers/pause` - Pause timer
- `POST /api/timers/resume` - Resume timer
- `POST /api/timers/stop` - Stop timer
- `GET /api/timers/current` - Get current active timer

Closes #5