### PR TITLE
feat: add record creation API with tag support

### DIFF
--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/RecordController.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/RecordController.kt
@@ -1,0 +1,46 @@
+package com.onuldo.adapter.inbound.web
+
+import com.onuldo.adapter.inbound.web.dto.CreateRecordRequest
+import com.onuldo.common.dto.ApiResponse
+import com.onuldo.common.security.SecurityUtils
+import com.onuldo.port.inbound.record.model.CreateRecordCommand
+import com.onuldo.port.inbound.record.model.RecordResponse
+import com.onuldo.port.inbound.record.usecase.CreateRecordUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
+
+@Tag(name = "Record", description = "기록 API")
+@RestController
+@RequestMapping("/api/records")
+class RecordController(
+    private val securityUtils: SecurityUtils,
+    private val createRecordUseCase: CreateRecordUseCase
+) {
+
+    @Operation(summary = "기록 생성", description = "새로운 활동 기록을 생성합니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createRecord(
+        request: HttpServletRequest,
+        @Valid @RequestBody body: CreateRecordRequest
+    ): ApiResponse<RecordResponse> {
+        val userId = securityUtils.getCurrentUserId(request)
+        val command = CreateRecordCommand(
+            userId = userId,
+            hobbyId = body.hobbyId,
+            timerId = body.timerId,
+            durationSeconds = body.durationSeconds,
+            memo = body.memo,
+            visibility = body.visibility,
+            tagNames = body.tags,
+            activityDate = body.activityDate ?: LocalDate.now()
+        )
+        val record = createRecordUseCase.execute(command)
+        return ApiResponse.success(record, message = "기록을 생성했습니다.")
+    }
+}

--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/CreateRecordRequest.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/CreateRecordRequest.kt
@@ -1,0 +1,25 @@
+package com.onuldo.adapter.inbound.web.dto
+
+import com.onuldo.domain.record.RecordVisibility
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class CreateRecordRequest(
+    @field:NotNull(message = "취미 ID는 필수입니다.")
+    val hobbyId: Long,
+
+    val timerId: Long? = null,
+
+    @field:NotNull(message = "활동 시간은 필수입니다.")
+    @field:Min(value = 1, message = "활동 시간은 1초 이상이어야 합니다.")
+    val durationSeconds: Int,
+
+    val memo: String? = null,
+
+    val visibility: RecordVisibility = RecordVisibility.PUBLIC,
+
+    val tags: List<String> = emptyList(),
+
+    val activityDate: LocalDate? = null
+)

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/record/RecordJpaRepository.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/record/RecordJpaRepository.kt
@@ -1,0 +1,11 @@
+package com.onuldo.adapter.outbound.persistence.record
+
+import com.onuldo.domain.record.Record
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
+
+interface RecordJpaRepository : JpaRepository<Record, Long> {
+    fun findByUserId(userId: Long): List<Record>
+    fun findByUserIdAndActivityDate(userId: Long, activityDate: LocalDate): List<Record>
+    fun findByUserIdAndActivityDateBetween(userId: Long, startDate: LocalDate, endDate: LocalDate): List<Record>
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/record/RecordRepositoryImpl.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/record/RecordRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package com.onuldo.adapter.outbound.persistence.record
+
+import com.onuldo.domain.record.Record
+import com.onuldo.port.outbound.record.RecordRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class RecordRepositoryImpl(
+    private val recordJpaRepository: RecordJpaRepository
+) : RecordRepository {
+
+    override fun save(record: Record): Record {
+        return recordJpaRepository.save(record)
+    }
+
+    override fun findById(id: Long): Record? {
+        return recordJpaRepository.findByIdOrNull(id)
+    }
+
+    override fun findByUserId(userId: Long): List<Record> {
+        return recordJpaRepository.findByUserId(userId)
+    }
+
+    override fun findByUserIdAndActivityDate(userId: Long, date: LocalDate): List<Record> {
+        return recordJpaRepository.findByUserIdAndActivityDate(userId, date)
+    }
+
+    override fun findByUserIdAndActivityDateBetween(userId: Long, startDate: LocalDate, endDate: LocalDate): List<Record> {
+        return recordJpaRepository.findByUserIdAndActivityDateBetween(userId, startDate, endDate)
+    }
+
+    override fun deleteById(id: Long) {
+        recordJpaRepository.deleteById(id)
+    }
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/tag/RecordTagJpaRepository.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/tag/RecordTagJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.onuldo.adapter.outbound.persistence.tag
+
+import com.onuldo.domain.tag.RecordTag
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RecordTagJpaRepository : JpaRepository<RecordTag, Long> {
+    fun findByRecordId(recordId: Long): List<RecordTag>
+    fun deleteByRecordId(recordId: Long)
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/tag/RecordTagRepositoryImpl.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/tag/RecordTagRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.onuldo.adapter.outbound.persistence.tag
+
+import com.onuldo.domain.tag.RecordTag
+import com.onuldo.port.outbound.tag.RecordTagRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class RecordTagRepositoryImpl(
+    private val recordTagJpaRepository: RecordTagJpaRepository
+) : RecordTagRepository {
+
+    override fun save(recordTag: RecordTag): RecordTag {
+        return recordTagJpaRepository.save(recordTag)
+    }
+
+    override fun saveAll(recordTags: List<RecordTag>): List<RecordTag> {
+        return recordTagJpaRepository.saveAll(recordTags)
+    }
+
+    override fun findByRecordId(recordId: Long): List<RecordTag> {
+        return recordTagJpaRepository.findByRecordId(recordId)
+    }
+
+    override fun deleteByRecordId(recordId: Long) {
+        recordTagJpaRepository.deleteByRecordId(recordId)
+    }
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/tag/TagJpaRepository.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/tag/TagJpaRepository.kt
@@ -1,0 +1,13 @@
+package com.onuldo.adapter.outbound.persistence.tag
+
+import com.onuldo.domain.tag.Tag
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface TagJpaRepository : JpaRepository<Tag, Long> {
+    fun findByName(name: String): Tag?
+    fun findByNameIn(names: List<String>): List<Tag>
+
+    @Query("SELECT t FROM Tag t ORDER BY t.usageCount DESC")
+    fun findPopularTags(limit: Int): List<Tag>
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/tag/TagRepositoryImpl.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/tag/TagRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.onuldo.adapter.outbound.persistence.tag
+
+import com.onuldo.domain.tag.Tag
+import com.onuldo.port.outbound.tag.TagRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class TagRepositoryImpl(
+    private val tagJpaRepository: TagJpaRepository
+) : TagRepository {
+
+    override fun save(tag: Tag): Tag {
+        return tagJpaRepository.save(tag)
+    }
+
+    override fun findById(id: Long): Tag? {
+        return tagJpaRepository.findByIdOrNull(id)
+    }
+
+    override fun findByName(name: String): Tag? {
+        return tagJpaRepository.findByName(name)
+    }
+
+    override fun findByNameIn(names: List<String>): List<Tag> {
+        return tagJpaRepository.findByNameIn(names)
+    }
+
+    override fun findPopularTags(limit: Int): List<Tag> {
+        return tagJpaRepository.findPopularTags(limit)
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/record/CreateRecordService.kt
+++ b/src/main/kotlin/com/onuldo/application/record/CreateRecordService.kt
@@ -1,0 +1,87 @@
+package com.onuldo.application.record
+
+import com.onuldo.common.exception.ResourceNotFoundException
+import com.onuldo.domain.record.Record
+import com.onuldo.domain.tag.RecordTag
+import com.onuldo.domain.tag.Tag
+import com.onuldo.port.inbound.record.model.CreateRecordCommand
+import com.onuldo.port.inbound.record.model.RecordResponse
+import com.onuldo.port.inbound.record.usecase.CreateRecordUseCase
+import com.onuldo.port.outbound.hobby.HobbyRepository
+import com.onuldo.port.outbound.record.RecordRepository
+import com.onuldo.port.outbound.tag.RecordTagRepository
+import com.onuldo.port.outbound.tag.TagRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CreateRecordService(
+    private val recordRepository: RecordRepository,
+    private val hobbyRepository: HobbyRepository,
+    private val tagRepository: TagRepository,
+    private val recordTagRepository: RecordTagRepository
+) : CreateRecordUseCase {
+
+    @Transactional
+    override fun execute(command: CreateRecordCommand): RecordResponse {
+        // Validate hobby exists
+        hobbyRepository.findById(command.hobbyId)
+            ?: throw ResourceNotFoundException("취미", command.hobbyId)
+
+        // Create record
+        val record = Record(
+            userId = command.userId,
+            hobbyId = command.hobbyId,
+            timerId = command.timerId,
+            durationSeconds = command.durationSeconds,
+            memo = command.memo,
+            visibility = command.visibility,
+            activityDate = command.activityDate
+        )
+
+        val savedRecord = recordRepository.save(record)
+        val recordId = savedRecord.id ?: throw IllegalStateException("기록 ID가 없습니다.")
+
+        // Process tags
+        val tagNames = processTags(command.tagNames, recordId)
+
+        return RecordResponse(
+            id = recordId,
+            userId = savedRecord.userId,
+            hobbyId = savedRecord.hobbyId,
+            timerId = savedRecord.timerId,
+            durationSeconds = savedRecord.durationSeconds,
+            memo = savedRecord.memo,
+            visibility = savedRecord.visibility,
+            activityDate = savedRecord.activityDate,
+            tags = tagNames,
+            createdAt = savedRecord.createdAt!!
+        )
+    }
+
+    private fun processTags(tagNames: List<String>, recordId: Long): List<String> {
+        if (tagNames.isEmpty()) return emptyList()
+
+        val normalizedNames = tagNames.map { it.trim().lowercase() }.distinct()
+        val existingTags = tagRepository.findByNameIn(normalizedNames)
+        val existingTagNames = existingTags.map { it.name }.toSet()
+
+        // Create new tags
+        val newTags = normalizedNames.filter { it !in existingTagNames }.map { name ->
+            tagRepository.save(Tag(name = name))
+        }
+
+        val allTags = existingTags + newTags
+
+        // Create record-tag associations and increment usage count
+        val recordTags = allTags.map { tag ->
+            tag.incrementUsageCount()
+            tagRepository.save(tag)
+            RecordTag(recordId = recordId, tagId = tag.id!!)
+        }
+
+        recordTagRepository.saveAll(recordTags)
+
+        return allTags.map { it.name }
+    }
+}

--- a/src/main/kotlin/com/onuldo/common/security/SecurityUtils.kt
+++ b/src/main/kotlin/com/onuldo/common/security/SecurityUtils.kt
@@ -1,0 +1,31 @@
+package com.onuldo.common.security
+
+import com.onuldo.common.exception.UnauthorizedException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+
+@Component
+class SecurityUtils(
+    private val jwtTokenProvider: JwtTokenProvider
+) {
+
+    fun getCurrentUserId(request: HttpServletRequest): Long {
+        val token = resolveToken(request)
+            ?: throw UnauthorizedException("인증 토큰이 필요합니다.")
+
+        if (!jwtTokenProvider.validateToken(token) || !jwtTokenProvider.isAccessToken(token)) {
+            throw UnauthorizedException("유효하지 않은 토큰입니다.")
+        }
+
+        return jwtTokenProvider.getUserId(token)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearer = request.getHeader("Authorization") ?: return null
+        return if (bearer.startsWith("Bearer ", ignoreCase = true)) {
+            bearer.substring(7)
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/domain/comment/Comment.kt
+++ b/src/main/kotlin/com/onuldo/domain/comment/Comment.kt
@@ -7,8 +7,6 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 
 /**
  * 댓글 엔티티

--- a/src/main/kotlin/com/onuldo/port/inbound/record/model/CreateRecordCommand.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/record/model/CreateRecordCommand.kt
@@ -1,0 +1,15 @@
+package com.onuldo.port.inbound.record.model
+
+import com.onuldo.domain.record.RecordVisibility
+import java.time.LocalDate
+
+data class CreateRecordCommand(
+    val userId: Long,
+    val hobbyId: Long,
+    val timerId: Long? = null,
+    val durationSeconds: Int,
+    val memo: String? = null,
+    val visibility: RecordVisibility = RecordVisibility.PUBLIC,
+    val tagNames: List<String> = emptyList(),
+    val activityDate: LocalDate = LocalDate.now()
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/record/model/RecordResponse.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/record/model/RecordResponse.kt
@@ -1,0 +1,18 @@
+package com.onuldo.port.inbound.record.model
+
+import com.onuldo.domain.record.RecordVisibility
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class RecordResponse(
+    val id: Long,
+    val userId: Long,
+    val hobbyId: Long,
+    val timerId: Long?,
+    val durationSeconds: Int,
+    val memo: String?,
+    val visibility: RecordVisibility,
+    val activityDate: LocalDate,
+    val tags: List<String>,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/record/usecase/CreateRecordUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/record/usecase/CreateRecordUseCase.kt
@@ -1,0 +1,8 @@
+package com.onuldo.port.inbound.record.usecase
+
+import com.onuldo.port.inbound.record.model.CreateRecordCommand
+import com.onuldo.port.inbound.record.model.RecordResponse
+
+interface CreateRecordUseCase {
+    fun execute(command: CreateRecordCommand): RecordResponse
+}

--- a/src/main/kotlin/com/onuldo/port/outbound/tag/RecordTagRepository.kt
+++ b/src/main/kotlin/com/onuldo/port/outbound/tag/RecordTagRepository.kt
@@ -1,0 +1,10 @@
+package com.onuldo.port.outbound.tag
+
+import com.onuldo.domain.tag.RecordTag
+
+interface RecordTagRepository {
+    fun save(recordTag: RecordTag): RecordTag
+    fun saveAll(recordTags: List<RecordTag>): List<RecordTag>
+    fun findByRecordId(recordId: Long): List<RecordTag>
+    fun deleteByRecordId(recordId: Long)
+}

--- a/src/main/kotlin/com/onuldo/port/outbound/tag/TagRepository.kt
+++ b/src/main/kotlin/com/onuldo/port/outbound/tag/TagRepository.kt
@@ -1,0 +1,11 @@
+package com.onuldo.port.outbound.tag
+
+import com.onuldo.domain.tag.Tag
+
+interface TagRepository {
+    fun save(tag: Tag): Tag
+    fun findById(id: Long): Tag?
+    fun findByName(name: String): Tag?
+    fun findByNameIn(names: List<String>): List<Tag>
+    fun findPopularTags(limit: Int): List<Tag>
+}


### PR DESCRIPTION
## Summary
- Add record creation API with tag system
- Support memo, visibility settings
- Auto-create tags if not exist

## API Endpoints
- `POST /api/records` - Create record with tags

Closes #7