### PR TITLE
feat: add follow/unfollow APIs

### DIFF
--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/FollowController.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/FollowController.kt
@@ -1,0 +1,82 @@
+package com.onuldo.adapter.inbound.web
+
+import com.onuldo.common.dto.ApiResponse
+import com.onuldo.common.security.SecurityUtils
+import com.onuldo.port.inbound.follow.model.FollowCountResponse
+import com.onuldo.port.inbound.follow.model.FollowUserResponse
+import com.onuldo.port.inbound.follow.usecase.FollowUserUseCase
+import com.onuldo.port.inbound.follow.usecase.GetFollowCountUseCase
+import com.onuldo.port.inbound.follow.usecase.GetFollowersUseCase
+import com.onuldo.port.inbound.follow.usecase.GetFollowingUseCase
+import com.onuldo.port.inbound.follow.usecase.UnfollowUserUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Follow", description = "팔로우 API")
+@RestController
+@RequestMapping("/api/users")
+class FollowController(
+    private val securityUtils: SecurityUtils,
+    private val followUserUseCase: FollowUserUseCase,
+    private val unfollowUserUseCase: UnfollowUserUseCase,
+    private val getFollowersUseCase: GetFollowersUseCase,
+    private val getFollowingUseCase: GetFollowingUseCase,
+    private val getFollowCountUseCase: GetFollowCountUseCase
+) {
+
+    @Operation(summary = "사용자 팔로우", description = "특정 사용자를 팔로우합니다.")
+    @PostMapping("/{userId}/follow")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun followUser(
+        request: HttpServletRequest,
+        @PathVariable userId: Long
+    ): ApiResponse<Unit> {
+        val currentUserId = securityUtils.getCurrentUserId(request)
+        followUserUseCase.execute(currentUserId, userId)
+        return ApiResponse.success(message = "팔로우했습니다.")
+    }
+
+    @Operation(summary = "사용자 언팔로우", description = "특정 사용자를 언팔로우합니다.")
+    @DeleteMapping("/{userId}/follow")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun unfollowUser(
+        request: HttpServletRequest,
+        @PathVariable userId: Long
+    ): ApiResponse<Unit> {
+        val currentUserId = securityUtils.getCurrentUserId(request)
+        unfollowUserUseCase.execute(currentUserId, userId)
+        return ApiResponse.success(message = "언팔로우했습니다.")
+    }
+
+    @Operation(summary = "팔로워 목록 조회", description = "특정 사용자의 팔로워 목록을 조회합니다.")
+    @GetMapping("/{userId}/followers")
+    fun getFollowers(
+        request: HttpServletRequest,
+        @PathVariable userId: Long
+    ): ApiResponse<List<FollowUserResponse>> {
+        val currentUserId = securityUtils.getCurrentUserId(request)
+        val followers = getFollowersUseCase.execute(userId, currentUserId)
+        return ApiResponse.success(followers, message = "팔로워 목록을 조회했습니다.")
+    }
+
+    @Operation(summary = "팔로잉 목록 조회", description = "특정 사용자의 팔로잉 목록을 조회합니다.")
+    @GetMapping("/{userId}/following")
+    fun getFollowing(
+        request: HttpServletRequest,
+        @PathVariable userId: Long
+    ): ApiResponse<List<FollowUserResponse>> {
+        val currentUserId = securityUtils.getCurrentUserId(request)
+        val following = getFollowingUseCase.execute(userId, currentUserId)
+        return ApiResponse.success(following, message = "팔로잉 목록을 조회했습니다.")
+    }
+
+    @Operation(summary = "팔로우 수 조회", description = "특정 사용자의 팔로워/팔로잉 수를 조회합니다.")
+    @GetMapping("/{userId}/follow-count")
+    fun getFollowCount(@PathVariable userId: Long): ApiResponse<FollowCountResponse> {
+        val count = getFollowCountUseCase.execute(userId)
+        return ApiResponse.success(count, message = "팔로우 수를 조회했습니다.")
+    }
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/follow/FollowJpaRepository.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/follow/FollowJpaRepository.kt
@@ -1,0 +1,18 @@
+package com.onuldo.adapter.outbound.persistence.follow
+
+import com.onuldo.domain.follow.Follow
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface FollowJpaRepository : JpaRepository<Follow, Long> {
+    fun findByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Follow?
+    fun existsByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Boolean
+    fun countByFollowerId(followerId: Long): Long
+    fun countByFollowingId(followingId: Long): Long
+
+    @Query("SELECT f.followingId FROM Follow f WHERE f.followerId = :followerId")
+    fun findFollowingIdsByFollowerId(followerId: Long): List<Long>
+
+    @Query("SELECT f.followerId FROM Follow f WHERE f.followingId = :followingId")
+    fun findFollowerIdsByFollowingId(followingId: Long): List<Long>
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/follow/FollowRepositoryImpl.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/follow/FollowRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package com.onuldo.adapter.outbound.persistence.follow
+
+import com.onuldo.domain.follow.Follow
+import com.onuldo.port.outbound.follow.FollowRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class FollowRepositoryImpl(
+    private val followJpaRepository: FollowJpaRepository
+) : FollowRepository {
+
+    override fun save(follow: Follow): Follow {
+        return followJpaRepository.save(follow)
+    }
+
+    override fun findByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Follow? {
+        return followJpaRepository.findByFollowerIdAndFollowingId(followerId, followingId)
+    }
+
+    override fun findFollowingIdsByFollowerId(followerId: Long): List<Long> {
+        return followJpaRepository.findFollowingIdsByFollowerId(followerId)
+    }
+
+    override fun findFollowerIdsByFollowingId(followingId: Long): List<Long> {
+        return followJpaRepository.findFollowerIdsByFollowingId(followingId)
+    }
+
+    override fun delete(follow: Follow) {
+        followJpaRepository.delete(follow)
+    }
+
+    override fun existsByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Boolean {
+        return followJpaRepository.existsByFollowerIdAndFollowingId(followerId, followingId)
+    }
+
+    override fun countByFollowerId(followerId: Long): Long {
+        return followJpaRepository.countByFollowerId(followerId)
+    }
+
+    override fun countByFollowingId(followingId: Long): Long {
+        return followJpaRepository.countByFollowingId(followingId)
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/follow/FollowUserService.kt
+++ b/src/main/kotlin/com/onuldo/application/follow/FollowUserService.kt
@@ -1,0 +1,39 @@
+package com.onuldo.application.follow
+
+import com.onuldo.common.exception.CustomException
+import com.onuldo.common.exception.ErrorCode
+import com.onuldo.common.exception.ResourceNotFoundException
+import com.onuldo.domain.follow.Follow
+import com.onuldo.port.inbound.follow.usecase.FollowUserUseCase
+import com.onuldo.port.outbound.follow.FollowRepository
+import com.onuldo.port.outbound.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class FollowUserService(
+    private val followRepository: FollowRepository,
+    private val userRepository: UserRepository
+) : FollowUserUseCase {
+
+    @Transactional
+    override fun execute(followerId: Long, followingId: Long) {
+        if (followerId == followingId) {
+            throw CustomException(ErrorCode.FOLLOW_SELF_NOT_ALLOWED)
+        }
+
+        userRepository.findById(followingId)
+            ?: throw ResourceNotFoundException("사용자", followingId)
+
+        if (followRepository.existsByFollowerIdAndFollowingId(followerId, followingId)) {
+            throw CustomException(ErrorCode.FOLLOW_ALREADY_EXISTS)
+        }
+
+        val follow = Follow(
+            followerId = followerId,
+            followingId = followingId
+        )
+
+        followRepository.save(follow)
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/follow/GetFollowCountService.kt
+++ b/src/main/kotlin/com/onuldo/application/follow/GetFollowCountService.kt
@@ -1,0 +1,24 @@
+package com.onuldo.application.follow
+
+import com.onuldo.port.inbound.follow.model.FollowCountResponse
+import com.onuldo.port.inbound.follow.usecase.GetFollowCountUseCase
+import com.onuldo.port.outbound.follow.FollowRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetFollowCountService(
+    private val followRepository: FollowRepository
+) : GetFollowCountUseCase {
+
+    @Transactional(readOnly = true)
+    override fun execute(userId: Long): FollowCountResponse {
+        val followingCount = followRepository.countByFollowerId(userId)
+        val followerCount = followRepository.countByFollowingId(userId)
+
+        return FollowCountResponse(
+            followingCount = followingCount,
+            followerCount = followerCount
+        )
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/follow/GetFollowersService.kt
+++ b/src/main/kotlin/com/onuldo/application/follow/GetFollowersService.kt
@@ -1,0 +1,33 @@
+package com.onuldo.application.follow
+
+import com.onuldo.port.inbound.follow.model.FollowUserResponse
+import com.onuldo.port.inbound.follow.usecase.GetFollowersUseCase
+import com.onuldo.port.outbound.follow.FollowRepository
+import com.onuldo.port.outbound.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetFollowersService(
+    private val followRepository: FollowRepository,
+    private val userRepository: UserRepository
+) : GetFollowersUseCase {
+
+    @Transactional(readOnly = true)
+    override fun execute(userId: Long, currentUserId: Long): List<FollowUserResponse> {
+        val followerIds = followRepository.findFollowerIdsByFollowingId(userId)
+        val currentUserFollowingIds = followRepository.findFollowingIdsByFollowerId(currentUserId).toSet()
+
+        return followerIds.mapNotNull { followerId ->
+            val user = userRepository.findById(followerId)
+            user?.let {
+                FollowUserResponse(
+                    userId = it.id!!,
+                    nickname = it.nickname,
+                    profileImageUrl = it.profileImageUrl,
+                    isFollowing = followerId in currentUserFollowingIds
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/follow/GetFollowingService.kt
+++ b/src/main/kotlin/com/onuldo/application/follow/GetFollowingService.kt
@@ -1,0 +1,33 @@
+package com.onuldo.application.follow
+
+import com.onuldo.port.inbound.follow.model.FollowUserResponse
+import com.onuldo.port.inbound.follow.usecase.GetFollowingUseCase
+import com.onuldo.port.outbound.follow.FollowRepository
+import com.onuldo.port.outbound.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetFollowingService(
+    private val followRepository: FollowRepository,
+    private val userRepository: UserRepository
+) : GetFollowingUseCase {
+
+    @Transactional(readOnly = true)
+    override fun execute(userId: Long, currentUserId: Long): List<FollowUserResponse> {
+        val followingIds = followRepository.findFollowingIdsByFollowerId(userId)
+        val currentUserFollowingIds = followRepository.findFollowingIdsByFollowerId(currentUserId).toSet()
+
+        return followingIds.mapNotNull { followingId ->
+            val user = userRepository.findById(followingId)
+            user?.let {
+                FollowUserResponse(
+                    userId = it.id!!,
+                    nickname = it.nickname,
+                    profileImageUrl = it.profileImageUrl,
+                    isFollowing = followingId in currentUserFollowingIds
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/follow/UnfollowUserService.kt
+++ b/src/main/kotlin/com/onuldo/application/follow/UnfollowUserService.kt
@@ -1,0 +1,22 @@
+package com.onuldo.application.follow
+
+import com.onuldo.common.exception.CustomException
+import com.onuldo.common.exception.ErrorCode
+import com.onuldo.port.inbound.follow.usecase.UnfollowUserUseCase
+import com.onuldo.port.outbound.follow.FollowRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UnfollowUserService(
+    private val followRepository: FollowRepository
+) : UnfollowUserUseCase {
+
+    @Transactional
+    override fun execute(followerId: Long, followingId: Long) {
+        val follow = followRepository.findByFollowerIdAndFollowingId(followerId, followingId)
+            ?: throw CustomException(ErrorCode.FOLLOW_NOT_FOUND)
+
+        followRepository.delete(follow)
+    }
+}

--- a/src/main/kotlin/com/onuldo/common/security/SecurityUtils.kt
+++ b/src/main/kotlin/com/onuldo/common/security/SecurityUtils.kt
@@ -1,0 +1,31 @@
+package com.onuldo.common.security
+
+import com.onuldo.common.exception.UnauthorizedException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+
+@Component
+class SecurityUtils(
+    private val jwtTokenProvider: JwtTokenProvider
+) {
+
+    fun getCurrentUserId(request: HttpServletRequest): Long {
+        val token = resolveToken(request)
+            ?: throw UnauthorizedException("인증 토큰이 필요합니다.")
+
+        if (!jwtTokenProvider.validateToken(token) || !jwtTokenProvider.isAccessToken(token)) {
+            throw UnauthorizedException("유효하지 않은 토큰입니다.")
+        }
+
+        return jwtTokenProvider.getUserId(token)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? {
+        val bearer = request.getHeader("Authorization") ?: return null
+        return if (bearer.startsWith("Bearer ", ignoreCase = true)) {
+            bearer.substring(7)
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/domain/comment/Comment.kt
+++ b/src/main/kotlin/com/onuldo/domain/comment/Comment.kt
@@ -7,8 +7,6 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 
 /**
  * 댓글 엔티티

--- a/src/main/kotlin/com/onuldo/port/inbound/follow/model/FollowUserResponse.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/follow/model/FollowUserResponse.kt
@@ -1,0 +1,13 @@
+package com.onuldo.port.inbound.follow.model
+
+data class FollowUserResponse(
+    val userId: Long,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val isFollowing: Boolean
+)
+
+data class FollowCountResponse(
+    val followingCount: Long,
+    val followerCount: Long
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/FollowUserUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/FollowUserUseCase.kt
@@ -1,0 +1,5 @@
+package com.onuldo.port.inbound.follow.usecase
+
+interface FollowUserUseCase {
+    fun execute(followerId: Long, followingId: Long)
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/GetFollowCountUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/GetFollowCountUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.follow.usecase
+
+import com.onuldo.port.inbound.follow.model.FollowCountResponse
+
+interface GetFollowCountUseCase {
+    fun execute(userId: Long): FollowCountResponse
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/GetFollowersUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/GetFollowersUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.follow.usecase
+
+import com.onuldo.port.inbound.follow.model.FollowUserResponse
+
+interface GetFollowersUseCase {
+    fun execute(userId: Long, currentUserId: Long): List<FollowUserResponse>
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/GetFollowingUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/GetFollowingUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.follow.usecase
+
+import com.onuldo.port.inbound.follow.model.FollowUserResponse
+
+interface GetFollowingUseCase {
+    fun execute(userId: Long, currentUserId: Long): List<FollowUserResponse>
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/UnfollowUserUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/follow/usecase/UnfollowUserUseCase.kt
@@ -1,0 +1,5 @@
+package com.onuldo.port.inbound.follow.usecase
+
+interface UnfollowUserUseCase {
+    fun execute(followerId: Long, followingId: Long)
+}

--- a/src/main/kotlin/com/onuldo/port/outbound/follow/FollowRepository.kt
+++ b/src/main/kotlin/com/onuldo/port/outbound/follow/FollowRepository.kt
@@ -1,0 +1,14 @@
+package com.onuldo.port.outbound.follow
+
+import com.onuldo.domain.follow.Follow
+
+interface FollowRepository {
+    fun save(follow: Follow): Follow
+    fun findByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Follow?
+    fun findFollowingIdsByFollowerId(followerId: Long): List<Long>
+    fun findFollowerIdsByFollowingId(followingId: Long): List<Long>
+    fun delete(follow: Follow)
+    fun existsByFollowerIdAndFollowingId(followerId: Long, followingId: Long): Boolean
+    fun countByFollowerId(followerId: Long): Long
+    fun countByFollowingId(followingId: Long): Long
+}

--- a/src/main/kotlin/com/onuldo/port/outbound/record/RecordRepository.kt
+++ b/src/main/kotlin/com/onuldo/port/outbound/record/RecordRepository.kt
@@ -1,0 +1,13 @@
+package com.onuldo.port.outbound.record
+
+import com.onuldo.domain.record.Record
+import java.time.LocalDate
+
+interface RecordRepository {
+    fun save(record: Record): Record
+    fun findById(id: Long): Record?
+    fun findByUserId(userId: Long): List<Record>
+    fun findByUserIdAndActivityDate(userId: Long, date: LocalDate): List<Record>
+    fun findByUserIdAndActivityDateBetween(userId: Long, startDate: LocalDate, endDate: LocalDate): List<Record>
+    fun deleteById(id: Long)
+}


### PR DESCRIPTION
## Summary
- Add follow/unfollow functionality
- Add followers/following list APIs
- Prevent self-follow

## API Endpoints
- `POST /api/users/{userId}/follow` - Follow user
- `DELETE /api/users/{userId}/follow` - Unfollow user
- `GET /api/users/{userId}/followers` - Get followers
- `GET /api/users/{userId}/following` - Get following
- `GET /api/users/{userId}/follow-count` - Get follow counts

Closes #11