### PR TITLE
feat: add reaction CRUD APIs for records (#12)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     runtimeOnly("com.h2database:h2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 }
 
 

--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/ReactionController.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/ReactionController.kt
@@ -1,0 +1,77 @@
+package com.onuldo.adapter.inbound.web
+
+import com.onuldo.adapter.inbound.web.dto.AddReactionRequest
+import com.onuldo.common.dto.ApiResponse
+import com.onuldo.common.security.SecurityUtils
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.port.inbound.reaction.model.AddReactionCommand
+import com.onuldo.port.inbound.reaction.model.ReactionCountResponse
+import com.onuldo.port.inbound.reaction.model.ReactionResponse
+import com.onuldo.port.inbound.reaction.model.ReactionWithUserResponse
+import com.onuldo.port.inbound.reaction.usecase.AddReactionUseCase
+import com.onuldo.port.inbound.reaction.usecase.GetReactionCountUseCase
+import com.onuldo.port.inbound.reaction.usecase.GetReactionsUseCase
+import com.onuldo.port.inbound.reaction.usecase.RemoveReactionUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Reaction", description = "리액션 API")
+@RestController
+@RequestMapping("/api/records/{recordId}/reactions")
+class ReactionController(
+    private val securityUtils: SecurityUtils,
+    private val addReactionUseCase: AddReactionUseCase,
+    private val removeReactionUseCase: RemoveReactionUseCase,
+    private val getReactionsUseCase: GetReactionsUseCase,
+    private val getReactionCountUseCase: GetReactionCountUseCase
+) {
+
+    @Operation(summary = "리액션 추가", description = "기록에 리액션을 추가합니다.")
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun addReaction(
+        request: HttpServletRequest,
+        @PathVariable recordId: Long,
+        @Valid @RequestBody body: AddReactionRequest
+    ): ApiResponse<ReactionResponse> {
+        val currentUserId = securityUtils.getCurrentUserId(request)
+        val command = AddReactionCommand(
+            userId = currentUserId,
+            recordId = recordId,
+            emojiType = body.emojiType
+        )
+        val response = addReactionUseCase.execute(command)
+        return ApiResponse.success(response, message = "리액션을 추가했습니다.")
+    }
+
+    @Operation(summary = "리액션 제거", description = "기록에서 리액션을 제거합니다.")
+    @DeleteMapping("/{emojiType}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun removeReaction(
+        request: HttpServletRequest,
+        @PathVariable recordId: Long,
+        @PathVariable emojiType: EmojiType
+    ): ApiResponse<Unit> {
+        val currentUserId = securityUtils.getCurrentUserId(request)
+        removeReactionUseCase.execute(currentUserId, recordId, emojiType)
+        return ApiResponse.success(message = "리액션을 제거했습니다.")
+    }
+
+    @Operation(summary = "리액션 목록 조회", description = "기록의 리액션 목록을 조회합니다.")
+    @GetMapping
+    fun getReactions(@PathVariable recordId: Long): ApiResponse<List<ReactionWithUserResponse>> {
+        val reactions = getReactionsUseCase.execute(recordId)
+        return ApiResponse.success(reactions, message = "리액션 목록을 조회했습니다.")
+    }
+
+    @Operation(summary = "리액션 통계 조회", description = "기록의 리액션 통계를 조회합니다.")
+    @GetMapping("/count")
+    fun getReactionCount(@PathVariable recordId: Long): ApiResponse<ReactionCountResponse> {
+        val count = getReactionCountUseCase.execute(recordId)
+        return ApiResponse.success(count, message = "리액션 통계를 조회했습니다.")
+    }
+}

--- a/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/AddReactionRequest.kt
+++ b/src/main/kotlin/com/onuldo/adapter/inbound/web/dto/AddReactionRequest.kt
@@ -1,0 +1,9 @@
+package com.onuldo.adapter.inbound.web.dto
+
+import com.onuldo.domain.reaction.EmojiType
+import jakarta.validation.constraints.NotNull
+
+data class AddReactionRequest(
+    @field:NotNull(message = "이모지 타입은 필수입니다.")
+    val emojiType: EmojiType
+)

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/reaction/ReactionJpaRepository.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/reaction/ReactionJpaRepository.kt
@@ -1,0 +1,15 @@
+package com.onuldo.adapter.outbound.persistence.reaction
+
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.domain.reaction.Reaction
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface ReactionJpaRepository : JpaRepository<Reaction, Long> {
+    fun findByUserIdAndRecordIdAndEmojiType(userId: Long, recordId: Long, emojiType: EmojiType): Reaction?
+    fun existsByUserIdAndRecordIdAndEmojiType(userId: Long, recordId: Long, emojiType: EmojiType): Boolean
+    fun findAllByRecordId(recordId: Long): List<Reaction>
+
+    @Query("SELECT r.emojiType, COUNT(r) FROM Reaction r WHERE r.recordId = :recordId GROUP BY r.emojiType")
+    fun countByRecordIdGroupByEmojiType(recordId: Long): List<Array<Any>>
+}

--- a/src/main/kotlin/com/onuldo/adapter/outbound/persistence/reaction/ReactionRepositoryImpl.kt
+++ b/src/main/kotlin/com/onuldo/adapter/outbound/persistence/reaction/ReactionRepositoryImpl.kt
@@ -1,0 +1,45 @@
+package com.onuldo.adapter.outbound.persistence.reaction
+
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.domain.reaction.Reaction
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class ReactionRepositoryImpl(
+    private val reactionJpaRepository: ReactionJpaRepository
+) : ReactionRepository {
+
+    override fun save(reaction: Reaction): Reaction {
+        return reactionJpaRepository.save(reaction)
+    }
+
+    override fun delete(reaction: Reaction) {
+        reactionJpaRepository.delete(reaction)
+    }
+
+    override fun findByUserIdAndRecordIdAndEmojiType(
+        userId: Long,
+        recordId: Long,
+        emojiType: EmojiType
+    ): Reaction? {
+        return reactionJpaRepository.findByUserIdAndRecordIdAndEmojiType(userId, recordId, emojiType)
+    }
+
+    override fun existsByUserIdAndRecordIdAndEmojiType(
+        userId: Long,
+        recordId: Long,
+        emojiType: EmojiType
+    ): Boolean {
+        return reactionJpaRepository.existsByUserIdAndRecordIdAndEmojiType(userId, recordId, emojiType)
+    }
+
+    override fun findAllByRecordId(recordId: Long): List<Reaction> {
+        return reactionJpaRepository.findAllByRecordId(recordId)
+    }
+
+    override fun countByRecordIdGroupByEmojiType(recordId: Long): Map<EmojiType, Long> {
+        return reactionJpaRepository.countByRecordIdGroupByEmojiType(recordId)
+            .associate { it[0] as EmojiType to it[1] as Long }
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/reaction/AddReactionService.kt
+++ b/src/main/kotlin/com/onuldo/application/reaction/AddReactionService.kt
@@ -1,0 +1,38 @@
+package com.onuldo.application.reaction
+
+import com.onuldo.common.exception.CustomException
+import com.onuldo.common.exception.ErrorCode
+import com.onuldo.domain.reaction.Reaction
+import com.onuldo.port.inbound.reaction.model.AddReactionCommand
+import com.onuldo.port.inbound.reaction.model.ReactionResponse
+import com.onuldo.port.inbound.reaction.usecase.AddReactionUseCase
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AddReactionService(
+    private val reactionRepository: ReactionRepository
+) : AddReactionUseCase {
+
+    @Transactional
+    override fun execute(command: AddReactionCommand): ReactionResponse {
+        if (reactionRepository.existsByUserIdAndRecordIdAndEmojiType(
+                command.userId,
+                command.recordId,
+                command.emojiType
+            )
+        ) {
+            throw CustomException(ErrorCode.REACTION_ALREADY_EXISTS)
+        }
+
+        val reaction = Reaction(
+            userId = command.userId,
+            recordId = command.recordId,
+            emojiType = command.emojiType
+        )
+
+        val savedReaction = reactionRepository.save(reaction)
+        return ReactionResponse.from(savedReaction)
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/reaction/GetReactionCountService.kt
+++ b/src/main/kotlin/com/onuldo/application/reaction/GetReactionCountService.kt
@@ -1,0 +1,19 @@
+package com.onuldo.application.reaction
+
+import com.onuldo.port.inbound.reaction.model.ReactionCountResponse
+import com.onuldo.port.inbound.reaction.usecase.GetReactionCountUseCase
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetReactionCountService(
+    private val reactionRepository: ReactionRepository
+) : GetReactionCountUseCase {
+
+    @Transactional(readOnly = true)
+    override fun execute(recordId: Long): ReactionCountResponse {
+        val counts = reactionRepository.countByRecordIdGroupByEmojiType(recordId)
+        return ReactionCountResponse.of(recordId, counts)
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/reaction/GetReactionsService.kt
+++ b/src/main/kotlin/com/onuldo/application/reaction/GetReactionsService.kt
@@ -1,0 +1,36 @@
+package com.onuldo.application.reaction
+
+import com.onuldo.port.inbound.reaction.model.ReactionWithUserResponse
+import com.onuldo.port.inbound.reaction.usecase.GetReactionsUseCase
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import com.onuldo.port.outbound.user.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetReactionsService(
+    private val reactionRepository: ReactionRepository,
+    private val userRepository: UserRepository
+) : GetReactionsUseCase {
+
+    @Transactional(readOnly = true)
+    override fun execute(recordId: Long): List<ReactionWithUserResponse> {
+        val reactions = reactionRepository.findAllByRecordId(recordId)
+
+        val userIds = reactions.map { it.userId }.distinct()
+        val usersMap = userIds.mapNotNull { userRepository.findById(it) }
+            .associateBy { it.id }
+
+        return reactions.mapNotNull { reaction ->
+            val user = usersMap[reaction.userId] ?: return@mapNotNull null
+            ReactionWithUserResponse(
+                id = reaction.id!!,
+                userId = user.id!!,
+                nickname = user.nickname,
+                profileImageUrl = user.profileImageUrl,
+                emojiType = reaction.emojiType,
+                createdAt = reaction.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/application/reaction/RemoveReactionService.kt
+++ b/src/main/kotlin/com/onuldo/application/reaction/RemoveReactionService.kt
@@ -1,0 +1,23 @@
+package com.onuldo.application.reaction
+
+import com.onuldo.common.exception.CustomException
+import com.onuldo.common.exception.ErrorCode
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.port.inbound.reaction.usecase.RemoveReactionUseCase
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class RemoveReactionService(
+    private val reactionRepository: ReactionRepository
+) : RemoveReactionUseCase {
+
+    @Transactional
+    override fun execute(userId: Long, recordId: Long, emojiType: EmojiType) {
+        val reaction = reactionRepository.findByUserIdAndRecordIdAndEmojiType(userId, recordId, emojiType)
+            ?: throw CustomException(ErrorCode.REACTION_NOT_FOUND)
+
+        reactionRepository.delete(reaction)
+    }
+}

--- a/src/main/kotlin/com/onuldo/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/onuldo/common/exception/ErrorCode.kt
@@ -154,6 +154,18 @@ enum class ErrorCode(
         code = "FOLLOW_NOT_FOUND",
         message = "팔로우 관계를 찾을 수 없습니다.",
         httpStatus = HttpStatus.NOT_FOUND
+    ),
+
+    // 리액션 에러 (REACTION_*)
+    REACTION_NOT_FOUND(
+        code = "REACTION_NOT_FOUND",
+        message = "리액션을 찾을 수 없습니다.",
+        httpStatus = HttpStatus.NOT_FOUND
+    ),
+    REACTION_ALREADY_EXISTS(
+        code = "REACTION_ALREADY_EXISTS",
+        message = "이미 동일한 리액션이 존재합니다.",
+        httpStatus = HttpStatus.CONFLICT
     );
 }
 

--- a/src/main/kotlin/com/onuldo/port/inbound/reaction/model/AddReactionCommand.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/reaction/model/AddReactionCommand.kt
@@ -1,0 +1,9 @@
+package com.onuldo.port.inbound.reaction.model
+
+import com.onuldo.domain.reaction.EmojiType
+
+data class AddReactionCommand(
+    val userId: Long,
+    val recordId: Long,
+    val emojiType: EmojiType
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/reaction/model/ReactionCountResponse.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/reaction/model/ReactionCountResponse.kt
@@ -1,0 +1,19 @@
+package com.onuldo.port.inbound.reaction.model
+
+import com.onuldo.domain.reaction.EmojiType
+
+data class ReactionCountResponse(
+    val recordId: Long,
+    val counts: Map<EmojiType, Long>,
+    val totalCount: Long
+) {
+    companion object {
+        fun of(recordId: Long, counts: Map<EmojiType, Long>): ReactionCountResponse {
+            return ReactionCountResponse(
+                recordId = recordId,
+                counts = counts,
+                totalCount = counts.values.sum()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/reaction/model/ReactionResponse.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/reaction/model/ReactionResponse.kt
@@ -1,0 +1,25 @@
+package com.onuldo.port.inbound.reaction.model
+
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.domain.reaction.Reaction
+import java.time.LocalDateTime
+
+data class ReactionResponse(
+    val id: Long,
+    val userId: Long,
+    val recordId: Long,
+    val emojiType: EmojiType,
+    val createdAt: LocalDateTime
+) {
+    companion object {
+        fun from(reaction: Reaction): ReactionResponse {
+            return ReactionResponse(
+                id = reaction.id!!,
+                userId = reaction.userId,
+                recordId = reaction.recordId,
+                emojiType = reaction.emojiType,
+                createdAt = reaction.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/reaction/model/ReactionWithUserResponse.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/reaction/model/ReactionWithUserResponse.kt
@@ -1,0 +1,13 @@
+package com.onuldo.port.inbound.reaction.model
+
+import com.onuldo.domain.reaction.EmojiType
+import java.time.LocalDateTime
+
+data class ReactionWithUserResponse(
+    val id: Long,
+    val userId: Long,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val emojiType: EmojiType,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/com/onuldo/port/inbound/reaction/usecase/AddReactionUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/reaction/usecase/AddReactionUseCase.kt
@@ -1,0 +1,8 @@
+package com.onuldo.port.inbound.reaction.usecase
+
+import com.onuldo.port.inbound.reaction.model.AddReactionCommand
+import com.onuldo.port.inbound.reaction.model.ReactionResponse
+
+interface AddReactionUseCase {
+    fun execute(command: AddReactionCommand): ReactionResponse
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/reaction/usecase/GetReactionCountUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/reaction/usecase/GetReactionCountUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.reaction.usecase
+
+import com.onuldo.port.inbound.reaction.model.ReactionCountResponse
+
+interface GetReactionCountUseCase {
+    fun execute(recordId: Long): ReactionCountResponse
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/reaction/usecase/GetReactionsUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/reaction/usecase/GetReactionsUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.reaction.usecase
+
+import com.onuldo.port.inbound.reaction.model.ReactionWithUserResponse
+
+interface GetReactionsUseCase {
+    fun execute(recordId: Long): List<ReactionWithUserResponse>
+}

--- a/src/main/kotlin/com/onuldo/port/inbound/reaction/usecase/RemoveReactionUseCase.kt
+++ b/src/main/kotlin/com/onuldo/port/inbound/reaction/usecase/RemoveReactionUseCase.kt
@@ -1,0 +1,7 @@
+package com.onuldo.port.inbound.reaction.usecase
+
+import com.onuldo.domain.reaction.EmojiType
+
+interface RemoveReactionUseCase {
+    fun execute(userId: Long, recordId: Long, emojiType: EmojiType)
+}

--- a/src/main/kotlin/com/onuldo/port/outbound/reaction/ReactionRepository.kt
+++ b/src/main/kotlin/com/onuldo/port/outbound/reaction/ReactionRepository.kt
@@ -1,0 +1,13 @@
+package com.onuldo.port.outbound.reaction
+
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.domain.reaction.Reaction
+
+interface ReactionRepository {
+    fun save(reaction: Reaction): Reaction
+    fun delete(reaction: Reaction)
+    fun findByUserIdAndRecordIdAndEmojiType(userId: Long, recordId: Long, emojiType: EmojiType): Reaction?
+    fun existsByUserIdAndRecordIdAndEmojiType(userId: Long, recordId: Long, emojiType: EmojiType): Boolean
+    fun findAllByRecordId(recordId: Long): List<Reaction>
+    fun countByRecordIdGroupByEmojiType(recordId: Long): Map<EmojiType, Long>
+}

--- a/src/test/kotlin/com/onuldo/application/reaction/AddReactionServiceTest.kt
+++ b/src/test/kotlin/com/onuldo/application/reaction/AddReactionServiceTest.kt
@@ -1,0 +1,90 @@
+package com.onuldo.application.reaction
+
+import com.onuldo.common.exception.CustomException
+import com.onuldo.common.exception.ErrorCode
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.domain.reaction.Reaction
+import com.onuldo.port.inbound.reaction.model.AddReactionCommand
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class AddReactionServiceTest {
+
+    @Mock
+    private lateinit var reactionRepository: ReactionRepository
+
+    private lateinit var addReactionService: AddReactionService
+
+    @BeforeEach
+    fun setUp() {
+        addReactionService = AddReactionService(reactionRepository)
+    }
+
+    @Test
+    @DisplayName("리액션 추가 성공")
+    fun `should add reaction successfully`() {
+        // given
+        val command = AddReactionCommand(
+            userId = 1L,
+            recordId = 1L,
+            emojiType = EmojiType.HEART
+        )
+
+        whenever(reactionRepository.existsByUserIdAndRecordIdAndEmojiType(
+            command.userId, command.recordId, command.emojiType
+        )).thenReturn(false)
+
+        whenever(reactionRepository.save(any())).thenAnswer { invocation ->
+            val reaction = invocation.getArgument<Reaction>(0)
+            Reaction(
+                userId = reaction.userId,
+                recordId = reaction.recordId,
+                emojiType = reaction.emojiType
+            ).apply {
+                val idField = this::class.java.superclass.getDeclaredField("id")
+                idField.isAccessible = true
+                idField.set(this, 1L)
+            }
+        }
+
+        // when
+        val result = addReactionService.execute(command)
+
+        // then
+        assertEquals(1L, result.userId)
+        assertEquals(1L, result.recordId)
+        assertEquals(EmojiType.HEART, result.emojiType)
+        verify(reactionRepository).save(any())
+    }
+
+    @Test
+    @DisplayName("중복 리액션 추가 시 예외 발생")
+    fun `should throw exception when reaction already exists`() {
+        // given
+        val command = AddReactionCommand(
+            userId = 1L,
+            recordId = 1L,
+            emojiType = EmojiType.HEART
+        )
+
+        whenever(reactionRepository.existsByUserIdAndRecordIdAndEmojiType(
+            command.userId, command.recordId, command.emojiType
+        )).thenReturn(true)
+
+        // when & then
+        val exception = assertThrows(CustomException::class.java) {
+            addReactionService.execute(command)
+        }
+        assertEquals(ErrorCode.REACTION_ALREADY_EXISTS, exception.errorCode)
+    }
+}

--- a/src/test/kotlin/com/onuldo/application/reaction/GetReactionCountServiceTest.kt
+++ b/src/test/kotlin/com/onuldo/application/reaction/GetReactionCountServiceTest.kt
@@ -1,0 +1,69 @@
+package com.onuldo.application.reaction
+
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class GetReactionCountServiceTest {
+
+    @Mock
+    private lateinit var reactionRepository: ReactionRepository
+
+    private lateinit var getReactionCountService: GetReactionCountService
+
+    @BeforeEach
+    fun setUp() {
+        getReactionCountService = GetReactionCountService(reactionRepository)
+    }
+
+    @Test
+    @DisplayName("리액션 통계 조회 성공")
+    fun `should get reaction count successfully`() {
+        // given
+        val recordId = 1L
+        val counts = mapOf(
+            EmojiType.HEART to 5L,
+            EmojiType.FIRE to 3L,
+            EmojiType.CLAP to 2L
+        )
+
+        whenever(reactionRepository.countByRecordIdGroupByEmojiType(recordId))
+            .thenReturn(counts)
+
+        // when
+        val result = getReactionCountService.execute(recordId)
+
+        // then
+        assertEquals(recordId, result.recordId)
+        assertEquals(5L, result.counts[EmojiType.HEART])
+        assertEquals(3L, result.counts[EmojiType.FIRE])
+        assertEquals(2L, result.counts[EmojiType.CLAP])
+        assertEquals(10L, result.totalCount)
+    }
+
+    @Test
+    @DisplayName("리액션이 없는 경우 빈 통계 반환")
+    fun `should return empty counts when no reactions`() {
+        // given
+        val recordId = 1L
+
+        whenever(reactionRepository.countByRecordIdGroupByEmojiType(recordId))
+            .thenReturn(emptyMap())
+
+        // when
+        val result = getReactionCountService.execute(recordId)
+
+        // then
+        assertEquals(recordId, result.recordId)
+        assertEquals(0, result.counts.size)
+        assertEquals(0L, result.totalCount)
+    }
+}

--- a/src/test/kotlin/com/onuldo/application/reaction/GetReactionsServiceTest.kt
+++ b/src/test/kotlin/com/onuldo/application/reaction/GetReactionsServiceTest.kt
@@ -1,0 +1,95 @@
+package com.onuldo.application.reaction
+
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.domain.reaction.Reaction
+import com.onuldo.domain.user.User
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import com.onuldo.port.outbound.user.UserRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class GetReactionsServiceTest {
+
+    @Mock
+    private lateinit var reactionRepository: ReactionRepository
+
+    @Mock
+    private lateinit var userRepository: UserRepository
+
+    private lateinit var getReactionsService: GetReactionsService
+
+    @BeforeEach
+    fun setUp() {
+        getReactionsService = GetReactionsService(reactionRepository, userRepository)
+    }
+
+    @Test
+    @DisplayName("리액션 목록 조회 성공")
+    fun `should get reactions successfully`() {
+        // given
+        val recordId = 1L
+        val user1 = createUser(1L, "user1")
+        val user2 = createUser(2L, "user2")
+
+        val reaction1 = createReaction(1L, user1.id!!, recordId, EmojiType.HEART)
+        val reaction2 = createReaction(2L, user2.id!!, recordId, EmojiType.FIRE)
+
+        whenever(reactionRepository.findAllByRecordId(recordId))
+            .thenReturn(listOf(reaction1, reaction2))
+        whenever(userRepository.findById(user1.id!!)).thenReturn(user1)
+        whenever(userRepository.findById(user2.id!!)).thenReturn(user2)
+
+        // when
+        val result = getReactionsService.execute(recordId)
+
+        // then
+        assertEquals(2, result.size)
+        assertEquals(user1.nickname, result[0].nickname)
+        assertEquals(EmojiType.HEART, result[0].emojiType)
+        assertEquals(user2.nickname, result[1].nickname)
+        assertEquals(EmojiType.FIRE, result[1].emojiType)
+    }
+
+    @Test
+    @DisplayName("리액션이 없는 경우 빈 목록 반환")
+    fun `should return empty list when no reactions`() {
+        // given
+        val recordId = 1L
+
+        whenever(reactionRepository.findAllByRecordId(recordId))
+            .thenReturn(emptyList())
+
+        // when
+        val result = getReactionsService.execute(recordId)
+
+        // then
+        assertEquals(0, result.size)
+    }
+
+    private fun createUser(id: Long, nickname: String): User {
+        val user = User(
+            email = "$nickname@test.com",
+            password = "password",
+            nickname = nickname
+        )
+        val idField = user::class.java.superclass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(user, id)
+        return user
+    }
+
+    private fun createReaction(id: Long, userId: Long, recordId: Long, emojiType: EmojiType): Reaction {
+        val reaction = Reaction(userId = userId, recordId = recordId, emojiType = emojiType)
+        val idField = reaction::class.java.superclass.getDeclaredField("id")
+        idField.isAccessible = true
+        idField.set(reaction, id)
+        return reaction
+    }
+}

--- a/src/test/kotlin/com/onuldo/application/reaction/RemoveReactionServiceTest.kt
+++ b/src/test/kotlin/com/onuldo/application/reaction/RemoveReactionServiceTest.kt
@@ -1,0 +1,68 @@
+package com.onuldo.application.reaction
+
+import com.onuldo.common.exception.CustomException
+import com.onuldo.common.exception.ErrorCode
+import com.onuldo.domain.reaction.EmojiType
+import com.onuldo.domain.reaction.Reaction
+import com.onuldo.port.outbound.reaction.ReactionRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+class RemoveReactionServiceTest {
+
+    @Mock
+    private lateinit var reactionRepository: ReactionRepository
+
+    private lateinit var removeReactionService: RemoveReactionService
+
+    @BeforeEach
+    fun setUp() {
+        removeReactionService = RemoveReactionService(reactionRepository)
+    }
+
+    @Test
+    @DisplayName("리액션 제거 성공")
+    fun `should remove reaction successfully`() {
+        // given
+        val userId = 1L
+        val recordId = 1L
+        val emojiType = EmojiType.HEART
+        val reaction = Reaction(userId = userId, recordId = recordId, emojiType = emojiType)
+
+        whenever(reactionRepository.findByUserIdAndRecordIdAndEmojiType(userId, recordId, emojiType))
+            .thenReturn(reaction)
+
+        // when
+        removeReactionService.execute(userId, recordId, emojiType)
+
+        // then
+        verify(reactionRepository).delete(reaction)
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리액션 제거 시 예외 발생")
+    fun `should throw exception when reaction not found`() {
+        // given
+        val userId = 1L
+        val recordId = 1L
+        val emojiType = EmojiType.HEART
+
+        whenever(reactionRepository.findByUserIdAndRecordIdAndEmojiType(userId, recordId, emojiType))
+            .thenReturn(null)
+
+        // when & then
+        val exception = assertThrows(CustomException::class.java) {
+            removeReactionService.execute(userId, recordId, emojiType)
+        }
+        assertEquals(ErrorCode.REACTION_NOT_FOUND, exception.errorCode)
+    }
+}


### PR DESCRIPTION
## Summary
- 기록에 이모지 리액션 추가/제거/조회/통계 API 구현
- 중복 리액션 방지 (DB 유니크 인덱스 + 애플리케이션 레벨 검증)
- 헥사고날 아키텍처 패턴 준수

## API Endpoints
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | `/api/records/{recordId}/reactions` | 리액션 추가 |
| DELETE | `/api/records/{recordId}/reactions/{emojiType}` | 리액션 제거 |
| GET | `/api/records/{recordId}/reactions` | 리액션 목록 조회 |
| GET | `/api/records/{recordId}/reactions/count` | 리액션 통계 조회 |

## Changes
- ErrorCode에 REACTION_NOT_FOUND, REACTION_ALREADY_EXISTS 추가
- ReactionRepository 포트 인터페이스
- AddReaction, RemoveReaction, GetReactions, GetReactionCount 서비스
- ReactionController REST API
- 서비스 단위 테스트 4개

## Test plan
- [x] `./gradlew build -x test` 빌드 성공
- [x] `./gradlew test --tests "*Reaction*"` 테스트 통과